### PR TITLE
Add PaymentFlow metadata

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -12,6 +12,8 @@ jobs:
          uses: php-actions/composer@v5
        - name: Running tests
          uses: php-actions/phpunit@v3
+           with:
+             version: 9.5        
    lint:
      runs-on: ubuntu-latest
      steps:

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -12,8 +12,8 @@ jobs:
          uses: php-actions/composer@v5
        - name: Running tests
          uses: php-actions/phpunit@v3
-           with:
-             version: 9.5        
+         with:
+           version: 9.5
    lint:
      runs-on: ubuntu-latest
      steps:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Plug Pagamentos for WooCommerce #
+# Malga Pagamentos for WooCommerce #
 **Contributors:** PlugTeam
 **Tags:** woocommerce, plug, gateway, payment  
 **Requires at least:** 5.6  
@@ -9,9 +9,8 @@
 
 ## Description ##
 
-Receba pagamentos por cartão de crédito, boleto bancário e pix utilizando a [Plug](https://www.plugpagamentos.com/?lang=en).
+Receba pagamentos por cartão de crédito, boleto bancário e pix utilizando a [Malga](https://www.malga.io).
 
-[![Gif Plug](https://static.wixstatic.com/media/656f2b_07e76b8231da4491880ac7a7981fb0ff~mv2.gif "Gif Plug")](https://www.plugpagamentos.com/ "Gif Plug")
 
 ### Compatibilidade ###
 
@@ -32,20 +31,35 @@ Você pode contribuir com código-fonte em nossa página no [GitHub](https://git
 
 ### Requerimentos: ###
 
-É necessário possuir uma conta na [Plug](https://www.plugpagamentos.com/) e ter instalado o [WooCommerce](http://wordpress.org/plugins/woocommerce/).
+É necessário possuir uma conta na [Malga](https://www.malga.io) e ter instalado o [WooCommerce](http://wordpress.org/plugins/woocommerce/).
 
 ### Configurações do Plugin: ###
 
-Com o plugin instalado acesse o admin do WordPress e entre em **"WooCommerce"** > **"Configurações"** > **"Pagamentos"** e configure as opção **"Plug"**:
+Com o plugin instalado acesse o admin do WordPress e entre em **"WooCommerce"** > **"Configurações"** > **"Pagamentos"** e configure as opção **"Malga"**:
 
 - Habilite o meio de pagamento que você deseja, preencha as opções de **X-Client-Id**, **X-Api-Key** e **MerchantId** com os dados que você recebeu da plug.
-- Configure uma Chave secreta para o seu webhook e logo apois faça o registro do mesmo na api da Plug, se tiver duvidas pode consultar nossa [documentação](https://docs.plugpagamentos.com/#section/Criacao-de-um-webhook)
+- Configure uma Chave secreta para o seu webhook e logo apois faça o registro do mesmo na api da Malga, se tiver duvidas pode consultar nossa [documentação](https://docs.plugpagamentos.com/#section/Criacao-de-um-webhook)
 
 *Também será necessário utilizar o plugin [WooCommerce Extra Checkout Fields for Brazil](http://wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/) para poder enviar campos de CPF e CNPJ.*
 
 Pronto, sua loja já pode receber pagamentos pela [Plug](https://www.plugpagamentos.com/?lang=en).
 
 Mais informações sobre nossa API pode consultar a [documentação](https://docs.plugpagamentos.com/) ou entrar em contato :)
+
+### Caso tenha que enviar um metadata ao PaymentFlow
+No fluxo  de pagamentos temos a opção de enviar dados adicionais para o orquestrador, o mesmo pode ser feito utilizando o filter malga_payment_flow como no exemplo a baixo:
+
+```
+function example_metadata( $metadata, $order, $post  ) {
+    foreach ( $order->get_items() as $item_id => $item ) { 
+		if($item->get_name() == 'test'){
+			$metadata['cnpj'] = '123';
+		}
+	}
+    return $metadata;
+}
+add_filter( 'malga_payment_flow', 'example_metadata', 10, 3 );
+```
 
 ## Testes ##
 

--- a/src/plugins/woocommerce-plug-payments/includes/class-plug-charges-adapter.php
+++ b/src/plugins/woocommerce-plug-payments/includes/class-plug-charges-adapter.php
@@ -77,6 +77,10 @@ class Plug_Charges_Adapter {
         }
     }
 
+    public function set_payment_flow( $metadata ) {
+        $this->payload['paymentFlow']['metadata'] = $metadata;
+    }
+
     public function to_credit( $post ) {
         if(!isset($post['plugpayments_card_installments'])) $post['plugpayments_card_installments'] = "1";
 
@@ -175,14 +179,8 @@ class Plug_Charges_Adapter {
         $sanitized = $this->payload;
 
         if($sanitized['paymentMethod']['paymentType'] == 'credit'){
-            $sanitized = array(
-                "sourceType" => "card",
-                "card"=> array(
-                    "cardNumber"=> '**** **** **** ****',
-                    "cardCvv"=> '***',
-                    "cardExpirationDate"=> '**/****',
-                    "cardHolderName"=> '**** ********** *******'
-                )
+            $sanitized['paymentSource']['paymentType'] = array(
+                "sourceType" => "card"
             );
         }
 

--- a/src/plugins/woocommerce-plug-payments/includes/class-wc-plug-api.php
+++ b/src/plugins/woocommerce-plug-payments/includes/class-wc-plug-api.php
@@ -31,6 +31,11 @@ class WC_PlugPayments_API {
 			$adapter->set_fraudanalysis($_POST, $order);
 		}
 
+        $payment_flow = apply_filters( 'malga_payment_flow', false, $order, $post );
+		if( $payment_flow ){
+			$adapter->set_payment_flow($payment_flow);
+		}
+
 		$return = $this->gateway->sdk->post_charge($adapter->payload);
 
 		if( 'yes' == $this->gateway->debuger ){

--- a/src/plugins/woocommerce-plug-payments/woocommerce-plug-payments.php
+++ b/src/plugins/woocommerce-plug-payments/woocommerce-plug-payments.php
@@ -57,18 +57,3 @@ class WC_Plug_Payments {
 
 add_action( 'plugins_loaded', array( 'WC_Plug_Payments', 'init' ) );
 add_action( 'plugins_loaded', array( 'WC_Plug_Payments', 'load_plugin_textdomain' ) );
-
-
-//Exemplo para definir metadata
-/*
-function example_metadata( $metadata, $order, $post  ) {
-    foreach ( $order->get_items() as $item_id => $item ) { 
-		if($item->get_name() == 'test'){
-			$metadata['cnpj'] = '123';
-		}
-	}
-
-    return $metadata;
-}
-add_filter( 'malga_payment_flow', 'example_metadata', 10, 3 );
-*/

--- a/src/plugins/woocommerce-plug-payments/woocommerce-plug-payments.php
+++ b/src/plugins/woocommerce-plug-payments/woocommerce-plug-payments.php
@@ -57,3 +57,16 @@ class WC_Plug_Payments {
 
 add_action( 'plugins_loaded', array( 'WC_Plug_Payments', 'init' ) );
 add_action( 'plugins_loaded', array( 'WC_Plug_Payments', 'load_plugin_textdomain' ) );
+
+
+//Exemplo para definir metadata
+function example_metadata( $metadata, $order, $post  ) {
+    foreach ( $order->get_items() as $item_id => $item ) { 
+		if($item->get_name() == 'test'){
+			$metadata['cnpj'] = '123';
+		}
+	}
+
+    return $metadata;
+}
+add_filter( 'malga_payment_flow', 'example_metadata', 10, 3 );

--- a/src/plugins/woocommerce-plug-payments/woocommerce-plug-payments.php
+++ b/src/plugins/woocommerce-plug-payments/woocommerce-plug-payments.php
@@ -60,6 +60,7 @@ add_action( 'plugins_loaded', array( 'WC_Plug_Payments', 'load_plugin_textdomain
 
 
 //Exemplo para definir metadata
+/*
 function example_metadata( $metadata, $order, $post  ) {
     foreach ( $order->get_items() as $item_id => $item ) { 
 		if($item->get_name() == 'test'){
@@ -70,3 +71,4 @@ function example_metadata( $metadata, $order, $post  ) {
     return $metadata;
 }
 add_filter( 'malga_payment_flow', 'example_metadata', 10, 3 );
+*/


### PR DESCRIPTION
Adicionando suporte ao envio de metadados para o PaymentFlow

### Caso tenha que enviar um metadata ao PaymentFlow
No fluxo  de pagamentos temos a opção de enviar dados adicionais para o orquestrador, o mesmo pode ser feito utilizando o filter malga_payment_flow como no exemplo a baixo:

```
function example_metadata( $metadata, $order, $post  ) {
    foreach ( $order->get_items() as $item_id => $item ) { 
		if($item->get_name() == 'test'){
			$metadata['cnpj'] = '123';
		}
	}
    return $metadata;
}
add_filter( 'malga_payment_flow', 'example_metadata', 10, 3 );
```